### PR TITLE
docs: fix simple typo, visiblity -> visibility

### DIFF
--- a/code/librg.h
+++ b/code/librg.h
@@ -25,8 +25,8 @@
  * 5.0.6 - Fix forced_inline on librg__space_insert
  * 5.0.5 - Fixes to selection and deduplication flow
  * 5.0.3 - Minor fixes by @markatk
- * 5.0.2 - Fixed issue related to visiblity destruction
- * 5.0.1 - Fixed entity visiblity states after disconnection
+ * 5.0.2 - Fixed issue related to visibility destruction
+ * 5.0.1 - Fixed entity visibility states after disconnection
  *
  * 5.0.0
  *  - Changed API for visibility feature:

--- a/code/source/entity.c
+++ b/code/source/entity.c
@@ -310,7 +310,7 @@ int8_t librg_entity_visibility_owner_set(librg_world *world, int64_t entity_id, 
     librg_entity_t *entity = librg_table_ent_get(&wld->entity_map, entity_id);
     if (entity == NULL) return LIBRG_ENTITY_UNTRACKED;
 
-    /* prevent setting visiblity, for your own entity, it will be always visible */
+    /* prevent setting visibility, for your own entity, it will be always visible */
     if (entity->owner_id == owner_id) {
         return LIBRG_ENTITY_VISIBILITY_IGNORED;
     }

--- a/code/source/query.c
+++ b/code/source/query.c
@@ -184,7 +184,7 @@ int32_t librg_world_query(librg_world *world, int64_t owner_id, int64_t *entity_
         librg_entity_t *entity = &wld->entity_map.entries[i].value;
         librg_table_i64 *chunks = librg_table_tbl_get(&dimensions, entity->dimension);
 
-        /* owner visiblity (personal)*/
+        /* owner visibility (personal)*/
         int8_t vis_owner = librg_entity_visibility_owner_get(world, entity_id, owner_id);
         if (vis_owner == LIBRG_VISIBLITY_NEVER) {
             continue; /* prevent from being included */
@@ -194,7 +194,7 @@ int32_t librg_world_query(librg_world *world, int64_t owner_id, int64_t *entity_
             continue;
         }
 
-        /* global entity visiblity */
+        /* global entity visibility */
         int8_t vis_global = librg_entity_visibility_global_get(world, entity_id);
         if (vis_global == LIBRG_VISIBLITY_NEVER) {
             continue; /* prevent from being included */

--- a/docs/defs/entity.md
+++ b/docs/defs/entity.md
@@ -367,7 +367,7 @@ int64_t librg_entity_owner_get(
 Sets current entity visibility radius.
 
 Visibility radius influences only entities that are owned.
-It represents a linear/circular/spherical (depending on world configuration) radius of entity visiblity in terms of nearby chunks,
+It represents a linear/circular/spherical (depending on world configuration) radius of entity visibility in terms of nearby chunks,
 and used whilist general visibility calculations in the [librg_world_query](def/query.md#librg_world_query) method.
 If property set for an entity that is not owned, but the owner is later on changed, it will be still applied, since the value is stored in the internal storage.
 


### PR DESCRIPTION
There is a small typo in code/librg.h, code/source/entity.c, code/source/query.c, docs/defs/entity.md.

Should read `visibility` rather than `visiblity`.

